### PR TITLE
re-add editables to dependencies

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -26,7 +26,6 @@ requirements:
   host:
     - pip
     - python ${{ python_min }}.*
-    # technically hatchling is required but we can't install it in our host environment as otherwise the package won't be picked up properly
     - packaging >=24.2
     - pathspec >=0.10.1
     - pluggy >=1.0.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 4d50b02aece6892b8cd0b3ce6c82cb218594d3ec5836dbde75bf41a21ab004c8
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
@@ -24,16 +24,17 @@ build:
 
 requirements:
   host:
+    - pip
+    - python ${{ python_min }}.*
+    # technically hatchling is required but we can't install it in our host environment as otherwise the package won't be picked up properly
     - packaging >=24.2
     - pathspec >=0.10.1
-    - pip
     - pluggy >=1.0.0
-    - python ${{ python_min }}.*
     - tomli >=1.2.2
     - trove-classifiers
   run:
     - python >=${{ python_min }}
-    - importlib-metadata
+    - editables >=0.3
     - packaging >=24.2
     - pathspec >=0.10.1
     - pluggy >=1.0.0


### PR DESCRIPTION
Updated build number and modified requirements.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

editables for some reason is not a strict requirement of hatchling (and not even mentioned as an extra dependency? they mention it in the code: https://github.com/pypa/hatch/blob/025f9c9c2fe54b806ff73adafe5916fa713d4cf0/backend/src/hatchling/builders/constants.py#L43) but it is still needed for editable installations.

i think editable installations are a use case that should be handled by the default build backend and that it should be part of the default package.
otherwise you would need to patch _every_ conda/pixi project where you are running `pip install -e .` (before, it was supported)